### PR TITLE
Enable darknet image to image::ImageBuffer conversion

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -3,6 +3,7 @@ use darknet_sys as sys;
 use image::{DynamicImage, ImageBuffer, Pixel};
 use std::{
     borrow::{Borrow, Cow},
+    convert::TryFrom,
     ops::Deref,
     os::raw::c_int,
     path::Path,
@@ -311,8 +312,7 @@ where
     }
 }
 
-// note: only traits defined in the current crate can be implemented for a type parameter (with rustc 1.40.0)
-/*impl<P> TryFrom<&Image> for ImageBuffer<P, Vec<P::Subpixel>>
+impl<P> TryFrom<&Image> for ImageBuffer<P, Vec<P::Subpixel>>
 where
     P: Pixel + 'static,
     P::Subpixel: 'static,
@@ -360,7 +360,7 @@ where
     fn try_from(from: Image) -> Result<Self, Self::Error> {
         Self::try_from(&from)
     }
-}*/
+}
 
 /// The traits converts input type to a copy-on-write image.
 pub trait IntoCowImage<'a> {


### PR DESCRIPTION
I see you left a comment that the `impl TryFrom<Image> for ImageBuffer<>` does not compile on rustc 1.40. Since 1.43.0, the rule is relaxed that it can succussfully compile on stable Rust. I think it's time to merge this feature to master.

If possible, I suggest updating your rust to newer stable version by `rustup update`. If you have whatever reason to stick to 1.40, we could use conditional compilation trick (adding features).