### PR TITLE
Update darknet-sys version and expose its features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["darknet", "machine-learning", "deep-learning", "neural-networks", "
 readme = "./README.md"
 
 [dependencies]
-darknet-sys = "^0.2.0"
+darknet-sys = "^0.2.2"
 image = "^0.23.1"
 libc = "^0.2.0"
 failure = "^0.1.8"
@@ -22,3 +22,8 @@ reqwest = { version = "^0.10.0", features = ["blocking"] }
 sha2 = "^0.8.1"
 hex = "^0.4.2"
 argh = "^0.1.3"
+
+[features]
+buildtime-bindgen = ["darknet-sys/buildtime-bindgen"]
+runtime = ["darknet-sys/runtime"]
+dylib = ["darknet-sys/dylib"]


### PR DESCRIPTION
The PR updates the depedent `darknet-sys` version and exposes its features. It is due to the fact that users using `darknet` crate cannot specify the feature set of dependent `darknet-sys` (even using `[patch]` in `Cargo.toml` does not work). Also, the current `darknet-sys` still cannot compile without `dylib` feature. The PR is an aid to this issue.