### PR TITLE
Expose more darknet sys features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,5 @@ argh = "^0.1.3"
 buildtime-bindgen = ["darknet-sys/buildtime-bindgen"]
 runtime = ["darknet-sys/runtime"]
 dylib = ["darknet-sys/dylib"]
+enable-opencv = ["darknet-sys/enable-opencv"]
+enable-cuda = ["darknet-sys/enable-cuda"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["darknet", "machine-learning", "deep-learning", "neural-networks", "
 readme = "./README.md"
 
 [dependencies]
-darknet-sys = "^0.2.0"
+darknet-sys = "^0.2.2"
 image = "^0.23.1"
 libc = "^0.2.0"
 failure = "^0.1.8"
@@ -22,3 +22,8 @@ reqwest = { version = "^0.10.0", features = ["blocking"] }
 sha2 = "^0.8.1"
 hex = "^0.4.2"
 argh = "^0.1.3"
+
+[features]
+buildtime-bindgen = ["darknet-sys/buildtime-bindgen"]
+runtime = ["darknet-sys/runtime"]
+dylib = ["darknet-sys/dylib"]


### PR DESCRIPTION
This PR extends #5. It adds more features from alianse777/darknet-sys-rust#5 to conditionally enable OpenCV and CUDA compilation. The patch must be blocked until the corresponding darknet-sys patch is merged and published to crates.io.