### PR TITLE
Migrate to anyhow and thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,18 @@ keywords = ["darknet", "machine-learning", "deep-learning", "neural-networks", "
 readme = "./README.md"
 
 [dependencies]
-darknet-sys = "^0.2.2"
-image = "^0.23.1"
-libc = "^0.2.0"
-failure = "^0.1.8"
-num-derive = "^0.3.0"
-num-traits = "^0.2.0"
+darknet-sys = "0.2"
+image = "0.23"
+libc = "0.2"
+failure = "0.1"
+num-derive = "0.3"
+num-traits = "0.2"
 
 [dev-dependencies]
-reqwest = { version = "^0.10.0", features = ["blocking"] }
-sha2 = "^0.8.1"
-hex = "^0.4.2"
-argh = "^0.1.3"
+reqwest = { version = "0.10", features = ["blocking"] }
+sha2 = "0.8"
+hex = "0.4"
+argh = "0.1"
 
 [features]
 buildtime-bindgen = ["darknet-sys/buildtime-bindgen"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "./README.md"
 darknet-sys = "0.2"
 image = "0.23"
 libc = "0.2"
-failure = "0.1"
+thiserror = "1.0"
 num-derive = "0.3"
 num-traits = "0.2"
 
@@ -22,6 +22,7 @@ reqwest = { version = "0.10", features = ["blocking"] }
 sha2 = "0.8"
 hex = "0.4"
 argh = "0.1"
+anyhow = "1.0"
 
 [features]
 buildtime-bindgen = ["darknet-sys/buildtime-bindgen"]

--- a/examples/run_inference.rs
+++ b/examples/run_inference.rs
@@ -1,6 +1,6 @@
+use anyhow::Result;
 use argh::FromArgs;
 use darknet::{BBox, Image, Network};
-use failure::Fallible;
 use image::RgbImage;
 use std::{
     convert::TryFrom,
@@ -34,7 +34,7 @@ struct Args {
     input_images: Vec<PathBuf>,
 }
 
-fn main() -> Fallible<()> {
+fn main() -> Result<()> {
     let Args {
         label_file,
         model_cfg,

--- a/examples/tiny_yolov3_inference.rs
+++ b/examples/tiny_yolov3_inference.rs
@@ -1,5 +1,5 @@
+use anyhow::Result;
 use darknet::{BBox, Image, Network};
-use failure::Fallible;
 use image::Rgb;
 use sha2::{Digest, Sha256};
 use std::{
@@ -19,7 +19,7 @@ const OUTPUT_DIR: &'static str = "./output";
 const OBJECTNESS_THRESHOLD: f32 = 0.9;
 const CLASS_PROB_THRESHOLD: f32 = 0.9;
 
-fn main() -> Fallible<()> {
+fn main() -> Result<()> {
     // download weights file
     fs::create_dir_all(OUTPUT_DIR)?;
     let weights_path = Path::new(OUTPUT_DIR).join(WEIGHTS_FILE_NAME);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,19 +1,19 @@
-use failure::Fail;
 use image::error::ImageError;
 use std::io;
+use thiserror::Error;
 
 /// The error type for this crate.
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum Error {
-    #[fail(display = "image error: {:?}", _0)]
+    #[error("image error: {0:?}")]
     ImageError(ImageError),
-    #[fail(display = "I/O error: {:?}", _0)]
+    #[error("I/O error: {0:?}")]
     IoError(io::Error),
-    #[fail(display = "encoding error: {:?}", reason)]
+    #[error("encoding error: {reason:?}")]
     EncodingError { reason: String },
-    #[fail(display = "internal error: {:?}", reason)]
+    #[error("internal error: {reason:?}")]
     InternalError { reason: String },
-    #[fail(display = "conversion error: {:?}", reason)]
+    #[error("conversion error: {reason:?}")]
     ConversionError { reason: String },
 }
 


### PR DESCRIPTION
It is announced on [failure README](https://github.com/rust-lang-nursery/failure) that it is deprecated, and suggests anyhow and thiserror alternatives. The PR strips off failure and replaces it with anyhow and thiserror.

Besides, it changes the version numbers in `Cargo.toml` to specify down to minor versions instead of patch versions. darknet-rust is a library crate, and I prefer to use less restrictive versions if possible. 