### PR TITLE
Add `enable-openmp` feature (forwarded to `darknet-sys`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["darknet", "machine-learning", "deep-learning", "neural-networks", "
 readme = "./README.md"
 
 [dependencies]
-darknet-sys = "0.3.1"
+darknet-sys = { version = "0.3.2", default-features = false }
 image = "0.23"
 libc = "0.2"
 thiserror = "1.0"
@@ -25,9 +25,11 @@ argh = "0.1"
 anyhow = "1.0"
 
 [features]
+default = ["enable-openmp"]
 buildtime-bindgen = ["darknet-sys/buildtime-bindgen"]
 runtime = ["darknet-sys/runtime"]
 dylib = ["darknet-sys/dylib"]
 enable-opencv = ["darknet-sys/enable-opencv"]
 enable-cuda = ["darknet-sys/enable-cuda"]
 enable-cudnn = ["darknet-sys/enable-cudnn"]
+enable-openmp = ["darknet-sys/enable-openmp"]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ By default, darknet will compile and link libdarknet statically. You can control
 - `enable-cuda`: Enable CUDA (expects CUDA 10.x and cuDNN 7.x).
 - `enable-cudnn`: Enable cuDNN
 - `enable-opencv`: Enable OpenCV.
+- `enable-openmp`: Enable OpenMP in darknet. Used for parallelization when running on the CPU. Enabled by default.
 - `runtime`: Link to libdarknet dynamic library. For example, `libdark.so` on Linux.
 - `dylib`: Build dynamic library instead of static
 - `buildtime-bindgen`: Generate bindings from libdarknet headers.


### PR DESCRIPTION
Depends on alianse777/darknet-sys-rust#16 - implements the idea presented in https://github.com/alianse777/darknet-sys-rust/pull/14#issuecomment-1103770763.

Enabling the flag by default should make this change backwards-compatible (no functional change),
except for users that were already specifying `default-features = false` for `darknet`.

CC @alianse777 @PabloMansanet @bschwind.