### PR TITLE
Updated darknet, added documentation and updated edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "darknet"
 version = "0.3.4"
 authors = ["alianse77"]
-edition = "2018"
+edition = "2021"
 description = "A Rust wrapper for Darknet, an open source neural network framework written in C and CUDA."
 repository = "https://github.com/alianse777/darknet-rust"
 license = "MIT"

--- a/src/detections.rs
+++ b/src/detections.rs
@@ -31,7 +31,7 @@ impl<'a> Detection<'a> {
 
     /// Get the class index with maximum probability.
     ///
-    /// The method accpets an optional probability thresholds.
+    /// The method accepts an optional probability thresholds.
     /// If the class with maximum probability os above tje threshold,
     /// it returns the tuple (class_id, corresponding_probability).
     /// Otherwise, it returns None.
@@ -90,7 +90,7 @@ pub struct Detections {
 
 impl Detections {
     /// Get a detection instance by index.
-    pub fn get<'a>(&'a self, index: usize) -> Option<Detection<'a>> {
+    pub fn get(&self, index: usize) -> Option<Detection> {
         if index >= self.n_detections {
             return None;
         }
@@ -108,7 +108,7 @@ impl Detections {
     }
 
     /// Get the iterator of a collection of detections.
-    pub fn iter<'a>(&'a self) -> DetectionsIter<'a> {
+    pub fn iter(&self) -> DetectionsIter {
         DetectionsIter {
             detections: self,
             index: 0,

--- a/src/detections.rs
+++ b/src/detections.rs
@@ -90,6 +90,11 @@ impl Detections {
         self.n_detections
     }
 
+    /// Returns `true` if the detections has a length of 0.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Get the iterator of a collection of detections.
     pub fn iter(&self) -> DetectionsIter {
         DetectionsIter {
@@ -130,7 +135,7 @@ impl<'a> Iterator for DetectionsIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let opt = self.detections.get(self.index);
-        if let Some(_) = opt {
+        if opt.is_some() {
             self.index += 1;
         }
         opt

--- a/src/image.rs
+++ b/src/image.rs
@@ -144,7 +144,7 @@ impl Image {
     }
 
     /// Returns pixel values as a slice.
-    pub fn get_data<'a>(&'a self) -> &'a [f32] {
+    pub fn get_data(&self) -> &[f32] {
         return unsafe {
             slice::from_raw_parts(
                 self.image.data,
@@ -154,7 +154,7 @@ impl Image {
     }
 
     /// Returns pixel values as a mutable slice.
-    pub fn get_data_mut<'a>(&'a self) -> &'a mut [f32] {
+    pub fn get_data_mut(&self) -> &mut [f32] {
         return unsafe {
             slice::from_raw_parts_mut(
                 self.image.data,

--- a/src/image.rs
+++ b/src/image.rs
@@ -20,41 +20,41 @@ where
 
 impl ConvertSubpixel for u8 {
     fn from_subpixel(from: Self) -> f32 {
-        from as f32 / std::u8::MAX as f32
+        from as f32 / u8::MAX as f32
     }
 
     fn to_subpixel(from: f32) -> Self {
-        (from * std::u8::MAX as f32) as u8
+        (from * u8::MAX as f32) as u8
     }
 }
 
 impl ConvertSubpixel for u16 {
     fn from_subpixel(from: Self) -> f32 {
-        from as f32 / std::u16::MAX as f32
+        from as f32 / u16::MAX as f32
     }
 
     fn to_subpixel(from: f32) -> Self {
-        (from * std::u16::MAX as f32) as u16
+        (from * u16::MAX as f32) as u16
     }
 }
 
 impl ConvertSubpixel for u32 {
     fn from_subpixel(from: Self) -> f32 {
-        from as f32 / std::u32::MAX as f32
+        from as f32 / u32::MAX as f32
     }
 
     fn to_subpixel(from: f32) -> Self {
-        (from * std::u32::MAX as f32) as u32
+        (from * u32::MAX as f32) as u32
     }
 }
 
 impl ConvertSubpixel for u64 {
     fn from_subpixel(from: Self) -> f32 {
-        from as f32 / std::u64::MAX as f32
+        from as f32 / u64::MAX as f32
     }
 
     fn to_subpixel(from: f32) -> Self {
-        (from * std::u64::MAX as f32) as u64
+        (from * u64::MAX as f32) as u64
     }
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -139,7 +139,7 @@ impl Image {
     }
 
     /// Returns pointer to raw image data.
-    pub unsafe fn get_raw_data(&self) -> *mut f32 {
+    pub fn get_raw_data(&self) -> *mut f32 {
         self.image.data
     }
 

--- a/src/kinds.rs
+++ b/src/kinds.rs
@@ -102,7 +102,7 @@ pub enum WeightsType {
     PerFeature = sys::WEIGHTS_TYPE_T_PER_FEATURE as usize,
 }
 
-/// Weights normalizion types.
+/// Weights normalization types.
 #[repr(usize)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, FromPrimitive)]
 pub enum WeightsNormalizion {

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -27,8 +27,8 @@ impl<'a> Layers<'a> {
 }
 
 impl<'a> IntoIterator for &'a Layers<'a> {
-    type IntoIter = LayersIter<'a>;
     type Item = Layer<'a>;
+    type IntoIter = LayersIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -47,7 +47,7 @@ impl<'a> Iterator for LayersIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let opt = self.layers.get(self.index);
-        if let Some(_) = opt {
+        if opt.is_some() {
             self.index += 1;
         }
         opt

--- a/src/network.rs
+++ b/src/network.rs
@@ -41,11 +41,14 @@ impl Network {
 
         let cfg_cstr = utils::path_to_cstring_or_error(cfg.as_ref())?;
 
+        let clear = c_int::from(clear);
+
         let ptr = unsafe {
             let raw_weights = weights_cstr
                 .as_ref()
                 .map_or(ptr::null_mut(), |cstr| cstr.as_ptr() as *mut _);
-            sys::load_network(cfg_cstr.as_ptr() as *mut _, raw_weights, clear as c_int)
+            let raw_cfg = cfg_cstr.as_ptr() as *mut _;
+            sys::load_network(raw_cfg, raw_weights, clear)
         };
 
         let net = NonNull::new(ptr).ok_or_else(|| Error::InternalError {

--- a/src/network.rs
+++ b/src/network.rs
@@ -44,8 +44,7 @@ impl Network {
         let ptr = unsafe {
             let raw_weights = weights_cstr
                 .as_ref()
-                .map(|cstr| cstr.as_ptr() as *mut _)
-                .unwrap_or(ptr::null_mut());
+                .map_or(ptr::null_mut(), |cstr| cstr.as_ptr() as *mut _);
             sys::load_network(cfg_cstr.as_ptr() as *mut _, raw_weights, clear as c_int)
         };
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -9,7 +9,6 @@ use darknet_sys as sys;
 
 use std::{
     ffi::c_void,
-    mem,
     os::raw::c_int,
     path::Path,
     ptr::{self, NonNull},
@@ -54,8 +53,8 @@ impl Network {
         })?;
 
         // drop paths here to avoid early deallocation
-        mem::drop(cfg_cstr);
-        mem::drop(weights_cstr);
+        drop(cfg_cstr);
+        drop(weights_cstr);
 
         Ok(Self { net })
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -22,6 +22,14 @@ pub struct Network {
 
 impl Network {
     /// Build the network instance from a configuration file and an optional weights file.
+    ///
+    /// This will abort the program with an exit code of 1 if any of the following occur.
+    /// - The config has no sections.
+    /// - The first section of the config is not `[net]` or `[network]`.
+    /// - `fopen` fails on [weights] (if provided).
+    /// - The weights file is invalid
+    ///
+    /// Returns an [Err] if [cfg] or [weights] (if provided) contain a null byte.
     pub fn load<C, W>(cfg: C, weights: Option<W>, clear: bool) -> Result<Network, Error>
     where
         C: AsRef<Path>,

--- a/src/network.rs
+++ b/src/network.rs
@@ -35,18 +35,11 @@ impl Network {
         C: AsRef<Path>,
         W: AsRef<Path>,
     {
-        // convert paths to CString
         let weights_cstr = weights
-            .map(|path| {
-                utils::path_to_cstring(path.as_ref()).ok_or_else(|| Error::EncodingError {
-                    reason: format!("the path {} is invalid", path.as_ref().display()),
-                })
-            })
+            .map(|path| utils::path_to_cstring_or_error(path.as_ref()))
             .transpose()?;
-        let cfg_cstr =
-            utils::path_to_cstring(cfg.as_ref()).ok_or_else(|| Error::EncodingError {
-                reason: format!("the path {} is invalid", cfg.as_ref().display()),
-            })?;
+
+        let cfg_cstr = utils::path_to_cstring_or_error(cfg.as_ref())?;
 
         let ptr = unsafe {
             let raw_weights = weights_cstr

--- a/src/network.rs
+++ b/src/network.rs
@@ -90,13 +90,13 @@ impl Network {
     }
 
     /// Get network layers.
-    pub fn layers<'a>(&'a self) -> Layers<'a> {
+    pub fn layers(&self) -> Layers {
         let layers = unsafe { slice::from_raw_parts(self.net.as_ref().layers, self.num_layers()) };
         Layers { layers }
     }
 
     /// Get layer by index.
-    pub fn get_layer<'a>(&'a self, index: usize) -> Option<Layer<'a>> {
+    pub fn get_layer(&self, index: usize) -> Option<Layer> {
         if index >= self.num_layers() {
             return None;
         }

--- a/src/train.rs
+++ b/src/train.rs
@@ -1,6 +1,6 @@
 use crate::{error::Error, utils};
 use darknet_sys as sys;
-use std::{mem, os::raw::c_int, path::Path, ptr};
+use std::{os::raw::c_int, path::Path, ptr};
 
 /// Train a detector model.
 pub fn train_detector<P1, P2, P3, P4, G>(
@@ -67,11 +67,11 @@ where
         );
     }
 
-    mem::drop(data_config_ctring);
-    mem::drop(model_config_ctring);
-    mem::drop(weights_ctring);
-    mem::drop(chart_cstring);
-    mem::drop(gpu_indexes_c_int);
+    drop(data_config_ctring);
+    drop(model_config_ctring);
+    drop(weights_ctring);
+    drop(chart_cstring);
+    drop(gpu_indexes_c_int);
 
     Ok(())
 }

--- a/src/train.rs
+++ b/src/train.rs
@@ -3,6 +3,7 @@ use darknet_sys as sys;
 use std::{os::raw::c_int, path::Path, ptr};
 
 /// Train a detector model.
+#[allow(clippy::too_many_arguments)]
 pub fn train_detector<P1, P2, P3, P4, G>(
     data_config_file: P1,
     model_config_file: P2,

--- a/src/train.rs
+++ b/src/train.rs
@@ -25,34 +25,12 @@ where
     P4: AsRef<Path>,
     G: AsRef<[usize]>,
 {
-    let data_config_ctring =
-        utils::path_to_cstring(data_config_file.as_ref()).ok_or_else(|| Error::EncodingError {
-            reason: format!(
-                "the path {} is invalid",
-                data_config_file.as_ref().display()
-            ),
-        })?;
-    let model_config_ctring =
-        utils::path_to_cstring(model_config_file.as_ref()).ok_or_else(|| Error::EncodingError {
-            reason: format!(
-                "the path {} is invalid",
-                model_config_file.as_ref().display()
-            ),
-        })?;
+    let data_config_ctring = utils::path_to_cstring_or_error(data_config_file.as_ref())?;
+    let model_config_ctring = utils::path_to_cstring_or_error(model_config_file.as_ref())?;
     let weights_ctring = weights_file
-        .map(|path| {
-            utils::path_to_cstring(path.as_ref()).ok_or_else(|| Error::EncodingError {
-                reason: format!(
-                    "the path {} is invalid",
-                    model_config_file.as_ref().display()
-                ),
-            })
-        })
+        .map(|path| utils::path_to_cstring_or_error(path.as_ref()))
         .transpose()?;
-    let chart_cstring =
-        utils::path_to_cstring(chart_file.as_ref()).ok_or_else(|| Error::EncodingError {
-            reason: format!("the path {} is invalid", chart_file.as_ref().display()),
-        })?;
+    let chart_cstring = utils::path_to_cstring_or_error(chart_file.as_ref())?;
     let gpu_indexes_c_int = gpu_indexes
         .as_ref()
         .iter()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,12 +1,14 @@
+use std::os::unix::ffi::OsStrExt;
 use std::{ffi::CString, path::Path};
 
 #[cfg(unix)]
 pub fn path_to_cstring(path: &Path) -> Option<CString> {
-    use std::os::unix::ffi::OsStrExt;
-    Some(CString::new(path.as_os_str().as_bytes()).unwrap())
+    CString::new(path.as_os_str().as_bytes()).ok()
 }
 
 #[cfg(not(unix))]
 pub fn path_to_cstring(path: &Path) -> Option<CString> {
-    path.to_str().map(|s| CString::new(s.as_bytes()).unwrap())
+    path.to_str()
+        .map(|s| CString::new(s.as_bytes()).ok())
+        .flatten()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,12 +1,12 @@
 use std::{ffi::CString, path::Path};
 
 #[cfg(unix)]
-pub fn path_to_cstring<'a>(path: &'a Path) -> Option<CString> {
+pub fn path_to_cstring(path: &Path) -> Option<CString> {
     use std::os::unix::ffi::OsStrExt;
     Some(CString::new(path.as_os_str().as_bytes()).unwrap())
 }
 
 #[cfg(not(unix))]
-pub fn path_to_cstring<'a>(path: &'a Path) -> Option<CString> {
+pub fn path_to_cstring(path: &Path) -> Option<CString> {
     path.to_str().map(|s| CString::new(s.as_bytes()).unwrap())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
+use crate::Error;
 use std::os::unix::ffi::OsStrExt;
 use std::{ffi::CString, path::Path};
-use crate::Error;
 
 #[cfg(unix)]
 pub fn path_to_cstring(path: &Path) -> Option<CString> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,16 @@
 use std::os::unix::ffi::OsStrExt;
 use std::{ffi::CString, path::Path};
+use crate::Error;
 
 #[cfg(unix)]
 pub fn path_to_cstring(path: &Path) -> Option<CString> {
     CString::new(path.as_os_str().as_bytes()).ok()
+}
+
+pub fn path_to_cstring_or_error(path: &Path) -> Result<CString, Error> {
+    path_to_cstring(path).ok_or_else(|| Error::EncodingError {
+        reason: format!("the path {:?} is invalid", path),
+    })
 }
 
 #[cfg(not(unix))]


### PR DESCRIPTION
There are a fair few changes here, but they are all mostly surface level.

Here are the highlights:

- Bumped the version of darknet. 
  - Looking over the commit messages there should be no breaking changes, 
- made `edition = 2021`.
  - This has the drawback of requiring a newer compiler, this library currently states a MSRV of 1.43.0. I figured with a minor version bump this should be okay considering the library is 0.x.x and 1.43.0 is now 2 and a bit years old now.
- Minor fixes.
  - removed unneeded lifetime annotations.
  - removed some duplicated code around error handling with `path_to_cstring`.
  - some use of equivalent but clearer functions (such as `map_or` in instead of `map` followed by `unwrap_or`).
  - removed uneeded unsafe from `get_raw_data`.
  - some documentation changes.

 I can split this into multiple PR's if you would prefer, each commit builds separately so it would be no issue.

Also to note is that there is some code that can lead to UB in safe code. `get_data_mut` returns a mutable reference from a shared reference. Clippy caught this and the reasoning for this being unsafe can be found [here](https://rust-lang.github.io/rust-clippy/master/index.html#mut_from_ref). The fix for this is to have `get_data_mut` take a mutable reference to self. This however is a breaking API change so I figured it does not fit in the scope of this PR.