### PR TITLE
update `image` and `darknet` dependancies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ keywords = [
 readme = "./README.md"
 
 [dependencies]
-darknet-sys = { version = "0.3.2", default-features = false }
+darknet-sys = { version = "0.4.0", default-features = false }
 image = "0.24"
 libc = "0.2"
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "./README.md"
 
 [dependencies]
 darknet-sys = { version = "0.3.2", default-features = false }
-image = "0.23"
+image = "0.24"
 libc = "0.2"
 thiserror = "1.0"
 num-derive = "0.3"

--- a/src/image.rs
+++ b/src/image.rs
@@ -245,12 +245,15 @@ impl<'a> From<&'a DynamicImage> for Image {
             DynamicImage::ImageLumaA8(image) => image.into(),
             DynamicImage::ImageRgb8(image) => image.into(),
             DynamicImage::ImageRgba8(image) => image.into(),
-            DynamicImage::ImageBgr8(image) => image.into(),
-            DynamicImage::ImageBgra8(image) => image.into(),
+            DynamicImage::ImageRgb32F(image) => image.into(),
+            DynamicImage::ImageRgba32F(image) => image.into(),
             DynamicImage::ImageLuma16(image) => image.into(),
             DynamicImage::ImageLumaA16(image) => image.into(),
             DynamicImage::ImageRgb16(image) => image.into(),
             DynamicImage::ImageRgba16(image) => image.into(),
+            // we must match the unknown case due to #[non_exhaustive] on DynamicImage. `rgba1` was
+            // chosen as it is the largest format and thus less likely to be a lossy conversion.
+            img => img.to_rgba16().into(),
         }
     }
 }


### PR DESCRIPTION
this bumps the image version to `0.24` from `0.23`. This was a breaking change to `image` - the api for `darknet` remains unchanged (minus of course forcing an update to crates depending directly on `image` and `darknet`). 

Some notes on the results for this can be found in the commit message for [c92f4b3](https://github.com/alianse777/darknet-rust/commit/c92f4b37d8bc8220e0833e71fd859624ae1a5579)

This also bumps `darknet-sys` to the version in a PR on that project. See the [PR](https://github.com/alianse777/darknet-sys-rust/pull/18) there for more info. 

This will fail to build until that PR lands.